### PR TITLE
Fix y axis

### DIFF
--- a/map-projection-distortions/main.js
+++ b/map-projection-distortions/main.js
@@ -31,7 +31,7 @@ function update(data) {
     },
     {
       name: label[0],
-      scale: d3.scale.linear().range([0, height]),
+      scale: d3.scale.linear().range([height, 0]),
       type: Number
     },
     {
@@ -41,7 +41,7 @@ function update(data) {
     },
     {
       name: label[2],
-      scale: d3.scale.sqrt().range([height, 0]),
+      scale: d3.scale.linear().range([height, 0]),
       type: Number
     },
     {


### PR DESCRIPTION
Map Projection Distortionsのバグ #48に対応する修正です。バグではありませんが、汎用性向上に関するものです。
オリジナルのコードはデータ項目１列目(ACC. 40º 150%)のみ、大きい数字が下に表示される設定になっていましたので他項目と同じく小さい数字が下に表示されるようにしました。また、３列目(AREAL)のみスケールにSQRT関数が適用されていたのでLinearにしました。