### PR TITLE
ID15 force-graph nodeが連番ではなくても表示されるように修正

### DIFF
--- a/force-graph/README.md
+++ b/force-graph/README.md
@@ -3,8 +3,6 @@ Force Graph
 
 Force Graph
 
-※nodeのidは、0から連番(順不同)で採番する必要があります。
-
 ## Data Format Sample
 
 | 'node' or 'link' | id(node) or source(link) | label(node) or target(link) |


### PR DESCRIPTION
nodeが連番(順不同)ではなくても表示されるように修正いたしました。
それにより、node、linkともにどのように行を削除しても、追加しても正常に表示されるようになりました。

また、前回の修正(issue#147)にて修正した箇所の整形も致しました。
（重複した処理があったため。）

以上、確認よろしくお願いいたします。