### PR TITLE
README追記

### DIFF
--- a/history-map/README.md
+++ b/history-map/README.md
@@ -1,7 +1,7 @@
 History Map Chart
 ====
 
-History Map Chart
+※写真をクリックすると拡大表示が出来ます。
 
 ## Data Format
 


### PR DESCRIPTION
history-mapの今と昔の写真の比較画面にて、写真を拡大して表示出来るということが分かりにくいと感じたため、READMEに注釈として記載致しました。

本当はREADMEに追記ではなく、今と昔の比較画面で何か拡大できることを表現できればいいとは思いますが、いいアイディアが思いつきませんでした。
