### PR TITLE
history-mapの初期表示緯度経度と地図のズームレベルを設定できるように変更

### DIFF
--- a/history-map/README.md
+++ b/history-map/README.md
@@ -5,6 +5,7 @@ History Map Chart
 
 ## Data Format
 
+| Center Latitude | Number | Center Longitude | Number | ZoomLevel | Number |
 | Area   | Spot Name | Description | Address | Latitude | Longitude | Era    | Old Picture | Now Picture | Sub Picture | Sub Picture |
 |--------|-----------|-------------|---------|----------|-----------|--------|-------------|-------------|-------------|-------------|
 | String | String    | String      | String  | Number   | Number    | String | Picture URL | Picture URL | Picture URL | Picture URL |

--- a/history-map/README.md
+++ b/history-map/README.md
@@ -5,7 +5,11 @@ History Map Chart
 
 ## Data Format
 
+1行目
 | Center Latitude | Number | Center Longitude | Number | ZoomLevel | Number |
+|--------|-----------|-------------|---------|----------|-----------|
+
+2行目以降
 | Area   | Spot Name | Description | Address | Latitude | Longitude | Era    | Old Picture | Now Picture | Sub Picture | Sub Picture |
 |--------|-----------|-------------|---------|----------|-----------|--------|-------------|-------------|-------------|-------------|
 | String | String    | String      | String  | Number   | Number    | String | Picture URL | Picture URL | Picture URL | Picture URL |

--- a/history-map/data.csv
+++ b/history-map/data.csv
@@ -1,3 +1,4 @@
+中心緯度,35.475846,中心経度,139.628833,ズームレベル,15
 名称,概要,住所,緯度,経度,年代,写真1URL(昔),写真2URL(今),写真3URL,写真4URL
 台町,歌川広重の東海道53次より（著作権保護期間満了）,横浜市神奈川区台町,35.470615,139.624439,江戸時代,https://ja.localwiki.org/yokohama/台町/_files/Tokaido03_Kanagawa.jpg,https://ja.localwiki.org/yokohama/台町/_files/IMG_20160416_145652.jpg,,
 青木橋,青木橋より本覚寺を望む（要クレジット表記）,横浜市神奈川区（青木橋上）,35.471019,139.62651,明治時代,https://farm3.staticflickr.com/2334/1541327391_a04c867fb4_o.jpg,https://ja.localwiki.org/yokohama/青木橋/_files/IMG_5972.JPG,,

--- a/history-map/main.js
+++ b/history-map/main.js
@@ -1,7 +1,9 @@
 //# require=d3,leaflet,es6-promise.min
 
-const HOME_LAT = 35.475846;
-const HOME_LNG = 139.628833;
+// 中心位置
+var homeLat;
+var homeLng;
+var zoomLevel;
 
 const PICT_MARGIN = 20;
 const MAIN_PICT_CONTAINER = 0.75;
@@ -20,17 +22,24 @@ d3.select('#map-container')
       'width': root.clientWidth + 'px'
   })
 
-// しぇあひるずを中心に表示  setView([緯度, 経度], ズーム)
-var mapLayer = L.map('map-container').setView([HOME_LAT, HOME_LNG], 15);
-
-L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
-}).addTo(mapLayer);
 
 function update(data) {
-    const SPOT_NAME_LABEL = data[0][0];
-    const LAT_LABEL = data[0][3];
-    const LNG_LABEL = data[0][4];
+    const SPOT_NAME_LABEL = data[1][0];
+    const LAT_LABEL = data[1][3];
+    const LNG_LABEL = data[1][4];
+
+    // 中心位置を取得 取得後にデータ読み込み部に合わせて1行目を削除
+    homeLat = data[0][1];
+    homeLng = data[0][3];
+    zoomLevel = data[0][5];
+    data.shift();
+
+    // 指定した緯度経度を中心に表示  setView([緯度, 経度], ズーム)
+    var mapLayer = L.map('map-container').setView([homeLat, homeLng], zoomLevel);
+
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
+    }).addTo(mapLayer);
 
     d3.selectAll('.leaflet-marker-icon')
       .remove()
@@ -123,9 +132,9 @@ function createContents(spot, data, spotName) {
 
     var pictContainerHeight = root.clientHeight
                               - document.getElementById('spot').clientHeight
-                              - document.getElementById('description').clientHeight 
-                              - document.getElementById('address').clientHeight 
-                              - (PICT_MARGIN * 2) 
+                              - document.getElementById('description').clientHeight
+                              - document.getElementById('address').clientHeight
+                              - (PICT_MARGIN * 2)
                               - (modalPadding * 2);
 
     var mainPictBox = modalContent
@@ -266,11 +275,11 @@ var getPictSize = function(self) {
     var pictSize = { };
     pictSize.width = parseInt(d3.select(self).style('width'));
     pictSize.height = parseInt(d3.select(self).style('height'));
-    return pictSize;          
+    return pictSize;
 }
 
 var is2PictHeightsMax = function(pictArray, pictContainerHeight) {
-    return pictArray[0].height == parseInt(pictContainerHeight) 
+    return pictArray[0].height == parseInt(pictContainerHeight)
         && pictArray[1].height == parseInt(pictContainerHeight);
 }
 


### PR DESCRIPTION
history-mapの初期表示緯度経度と地図のズームレベルを設定できるように変更しました。
違う地域のデータで展開する際に、これらを設定したくなると思います。
とり急ぎの対応でありますが、よろしければマージをお願いいたします。
#303 